### PR TITLE
Generated id retrieval and null to default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .idea
 target
-src/test

--- a/src/main/java/dev/gump/WormColumn.java
+++ b/src/main/java/dev/gump/WormColumn.java
@@ -5,24 +5,42 @@ public class WormColumn {
     private final String sqlName;
     private final String sqlCreation;
     private final boolean idColumn;
+    private final boolean autoIncrement;
 
-    public WormColumn(String columnName, String sqlCreation){
+    public WormColumn(String columnName, String sqlCreation) {
         this.fieldName = columnName;
         this.sqlName = columnName;
         this.sqlCreation = sqlCreation;
         this.idColumn = false;
+        this.autoIncrement = false;
     }
-    public WormColumn(String columnName, String sqlCreation, boolean idColumn){
+    public WormColumn(String columnName, String sqlCreation, boolean idColumn) {
         this.fieldName = columnName;
         this.sqlName = columnName;
         this.sqlCreation = sqlCreation;
         this.idColumn = idColumn;
+        this.autoIncrement = false;
     }
-    public WormColumn(String columnName, String sqlName, String sqlCreation, boolean idColumn){
+    public WormColumn(String columnName, String sqlName, String sqlCreation, boolean idColumn) {
         this.fieldName = columnName;
         this.sqlName = sqlName;
         this.sqlCreation = sqlCreation;
         this.idColumn = idColumn;
+        this.autoIncrement = false;
+    }
+    public WormColumn(String columnName, String sqlCreation, boolean idColumn, boolean autoIncrement) {
+        this.fieldName = columnName;
+        this.sqlName = columnName;
+        this.sqlCreation = sqlCreation;
+        this.idColumn = idColumn;
+        this.autoIncrement = autoIncrement;
+    }
+    public WormColumn(String columnName, String sqlName, String sqlCreation, boolean idColumn, boolean autoIncrement) {
+        this.fieldName = columnName;
+        this.sqlName = sqlName;
+        this.sqlCreation = sqlCreation;
+        this.idColumn = idColumn;
+        this.autoIncrement = autoIncrement;
     }
 
     public String getFieldName() {
@@ -39,5 +57,9 @@ public class WormColumn {
 
     public boolean isId() {
         return idColumn;
+    }
+
+    public boolean isAutoIncrement() {
+        return autoIncrement;
     }
 }

--- a/src/main/java/dev/gump/WormConnector.java
+++ b/src/main/java/dev/gump/WormConnector.java
@@ -5,12 +5,13 @@ import com.zaxxer.hikari.HikariDataSource;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.Statement;
 
 public class WormConnector {
     private static HikariDataSource hikariDataSource;
     private static boolean isDebug;
 
-    public static void init(WormConnection wormConnection){
+    public static void init(WormConnection wormConnection) {
         WormConnector.isDebug = wormConnection.isDebug();
 
         HikariConfig hikariConfig = new HikariConfig();
@@ -29,5 +30,13 @@ public class WormConnector {
 
         Connection connection = hikariDataSource.getConnection();
         return new WormQuery(connection, connection.prepareStatement(sql));
+    }
+
+    public static WormQuery QueryWithGeneratedKeys(String sql) throws SQLException {
+        if(isDebug)
+            System.out.println("[SQL] " + sql);
+
+        Connection connection = hikariDataSource.getConnection();
+        return new WormQuery(connection, connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS));
     }
 }


### PR DESCRIPTION
If a Insert call is made with a table that has a id and a auto_increment column, it will retrieve the auto incremented id from the query.

If a Insert, Update and Delete call is made with a field that has null value, instead of NULL it will put a DEFAULT.

With this two modifications, a Insert call with a null id will result in a filled id field after the call.