### PR TITLE
Added type adapters

### DIFF
--- a/src/main/java/dev/gump/worm/Worm.java
+++ b/src/main/java/dev/gump/worm/Worm.java
@@ -18,12 +18,14 @@ public class Worm {
     private static final Logger logger = LoggerFactory.getLogger("Worm Logger");
 
     private final WormRegistry wormRegistry;
+    private final WormTypeAdapterRegistry wormTypeAdapterRegistry;
     private final ExecutorService executor;
     private HikariDataSource hikariDataSource;
     private boolean isDebug;
 
     private Worm() {
         this.wormRegistry = new WormRegistry();
+        this.wormTypeAdapterRegistry = new WormTypeAdapterRegistry();
         this.executor = Executors.newCachedThreadPool();
     }
 
@@ -58,6 +60,10 @@ public class Worm {
 
     public static WormRegistry getRegistry() {
         return instance.wormRegistry;
+    }
+
+    public static WormTypeAdapterRegistry getTypeAdapterRegistry() {
+        return instance.wormTypeAdapterRegistry;
     }
 
     public static WormQuery query(String sql) throws SQLException {

--- a/src/main/java/dev/gump/worm/WormTypeAdapterRegistry.java
+++ b/src/main/java/dev/gump/worm/WormTypeAdapterRegistry.java
@@ -1,0 +1,32 @@
+package dev.gump.worm;
+
+import dev.gump.worm.typeadapter.*;
+
+import java.math.BigDecimal;
+import java.sql.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public final class WormTypeAdapterRegistry {
+
+    private final Map<Class<?>, WormTypeAdapter<?>> typeAdapterMap = new HashMap<>();
+
+    WormTypeAdapterRegistry() {
+        this.registerTypeAdapter(UUID.class, new UUIDTypeAdapter());
+        this.registerTypeAdapter(BigDecimal.class, new BigDecimalTypeAdapter());
+        this.registerTypeAdapter(Date.class, new DateTypeAdapter());
+        this.registerTypeAdapter(Time.class, new TimeTypeAdapter());
+        this.registerTypeAdapter(Timestamp.class, new TimestampTypeAdapter());
+    }
+
+    public <T> void registerTypeAdapter(Class<T> typeClass, WormTypeAdapter<T> typeAdapter) {
+        this.typeAdapterMap.put(typeClass, typeAdapter);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> WormTypeAdapter<T> getTypeAdapter(Class<T> typeClass) {
+        return (WormTypeAdapter<T>) this.typeAdapterMap.get(typeClass);
+    }
+
+}

--- a/src/main/java/dev/gump/worm/typeadapter/BigDecimalTypeAdapter.java
+++ b/src/main/java/dev/gump/worm/typeadapter/BigDecimalTypeAdapter.java
@@ -1,0 +1,17 @@
+package dev.gump.worm.typeadapter;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class BigDecimalTypeAdapter implements WormTypeAdapter<BigDecimal> {
+    @Override
+    public String toDatabase(BigDecimal input) {
+        return input.toString();
+    }
+
+    @Override
+    public BigDecimal fromDatabase(ResultSet resultSet, String columnName) throws SQLException {
+        return resultSet.getBigDecimal(columnName);
+    }
+}

--- a/src/main/java/dev/gump/worm/typeadapter/DateTypeAdapter.java
+++ b/src/main/java/dev/gump/worm/typeadapter/DateTypeAdapter.java
@@ -1,0 +1,17 @@
+package dev.gump.worm.typeadapter;
+
+import java.sql.Date;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class DateTypeAdapter implements WormTypeAdapter<Date> {
+    @Override
+    public String toDatabase(Date input) {
+        return input.toString();
+    }
+
+    @Override
+    public Date fromDatabase(ResultSet resultSet, String columnName) throws SQLException {
+        return resultSet.getDate(columnName);
+    }
+}

--- a/src/main/java/dev/gump/worm/typeadapter/TimeTypeAdapter.java
+++ b/src/main/java/dev/gump/worm/typeadapter/TimeTypeAdapter.java
@@ -1,0 +1,17 @@
+package dev.gump.worm.typeadapter;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Time;
+
+public class TimeTypeAdapter implements WormTypeAdapter<Time> {
+    @Override
+    public String toDatabase(Time input) {
+        return input.toString();
+    }
+
+    @Override
+    public Time fromDatabase(ResultSet resultSet, String columnName) throws SQLException {
+        return resultSet.getTime(columnName);
+    }
+}

--- a/src/main/java/dev/gump/worm/typeadapter/TimestampTypeAdapter.java
+++ b/src/main/java/dev/gump/worm/typeadapter/TimestampTypeAdapter.java
@@ -1,0 +1,17 @@
+package dev.gump.worm.typeadapter;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+
+public class TimestampTypeAdapter implements WormTypeAdapter<Timestamp> {
+    @Override
+    public String toDatabase(Timestamp input) {
+        return input.toString();
+    }
+
+    @Override
+    public Timestamp fromDatabase(ResultSet resultSet, String columnName) throws SQLException {
+        return resultSet.getTimestamp(columnName);
+    }
+}

--- a/src/main/java/dev/gump/worm/typeadapter/UUIDTypeAdapter.java
+++ b/src/main/java/dev/gump/worm/typeadapter/UUIDTypeAdapter.java
@@ -1,0 +1,17 @@
+package dev.gump.worm.typeadapter;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+
+public class UUIDTypeAdapter implements WormTypeAdapter<UUID> {
+    @Override
+    public String toDatabase(UUID input) {
+        return input.toString();
+    }
+
+    @Override
+    public UUID fromDatabase(ResultSet resultSet, String columnName) throws SQLException {
+        return UUID.fromString(resultSet.getString(columnName));
+    }
+}

--- a/src/main/java/dev/gump/worm/typeadapter/WormTypeAdapter.java
+++ b/src/main/java/dev/gump/worm/typeadapter/WormTypeAdapter.java
@@ -1,0 +1,12 @@
+package dev.gump.worm.typeadapter;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public interface WormTypeAdapter<T> {
+
+    String toDatabase(T input);
+
+    T fromDatabase(ResultSet resultSet, String columnName) throws SQLException;
+
+}


### PR DESCRIPTION
This allows the usage of complex data types like UUID and ItemStack[] to be used as the field's type and only when database operations occurs it adapts to a database friendly type