### PR TITLE
Fix foreign key generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.gump</groupId>
     <artifactId>worm</artifactId>
-    <version>1.1.4</version>
+    <version>1.1.7</version>
 
     <distributionManagement>
         <snapshotRepository>

--- a/src/main/java/dev/gump/worm/field/FieldType.java
+++ b/src/main/java/dev/gump/worm/field/FieldType.java
@@ -2,6 +2,7 @@ package dev.gump.worm.field;
 
 import dev.gump.worm.entity.Entity;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
@@ -21,7 +22,8 @@ public enum FieldType {
     TIME("TIME", List.of(), true),
     TIMESTAMP("TIMESTAMP", List.of(), true),
     BOOL("BOOL", List.of(Boolean.class)),
-    ENTITY("ENTITY",List.of(Entity.class), true);
+    ENTITY("ENTITY",List.of(Entity.class), true),
+    DECIMAL("DECIMAL(19,2)", List.of(BigDecimal.class), true);
     private final String value;
     private final List<Class<?>> classes;
     private final boolean needAsps;

--- a/src/main/java/dev/gump/worm/field/WormField.java
+++ b/src/main/java/dev/gump/worm/field/WormField.java
@@ -103,16 +103,29 @@ public class WormField {
     public String getSqlCreation(){
         if(type == FieldType.ENTITY && fieldClass_relational != null){
             EntityMeta cMeta = Worm.getRegistry().getTableMeta(fieldClass_relational);
-            if(cMeta.getUniqueKeyColumns().size() != 1)
+            if (cMeta.getUniqueKeyColumns().size() != 1)
                 throw new WormException("Relational Worm tables need to have only one unique keys");
+
             WormField key = cMeta.getUniqueKeyColumns().toArray(WormField[]::new)[0];
-            StringBuilder sql = new StringBuilder(key.getSqlCreation());
-            sql.append(", CONSTRAINT FK_").append(getName()).append("_").append(cMeta.getName()).append(" FOREIGN KEY (").append(getName()).append(") REFERENCES ")
+
+            StringBuilder sql = new StringBuilder();
+            sql.append(key.getType().getValue());
+            if (key.getLength() > 0)
+                sql.append('(').append(key.getLength()).append(')');
+
+            if (!nullable)
+                sql.append(" NOT NULL");
+
+            sql.append(", CONSTRAINT FK_").append(getName()).append("_").append(cMeta.getName())
+                    .append(" FOREIGN KEY (").append(getName()).append(") REFERENCES ")
                     .append(cMeta.getName()).append(" (").append(key.getName()).append(")");
-            if(onDelete != null)
-                sql.append(" ON DELETE ").append(onDelete.getValue());
-            if(onUpdate != null)
-                sql.append(" ON UPDATE ").append(onUpdate.getValue());
+
+            if (onDelete != null)
+                sql.append(" ON DELETE ").append(onDelete.name());
+
+            if (onUpdate != null)
+                sql.append(" ON UPDATE ").append(onUpdate.name());
+
             return sql.toString();
         }
 


### PR DESCRIPTION
If an entity was used as a field (to generate a relationship) and the primary key of this entity contained the AUTO_INCREMENT attribute, it was loaded along with the query, generating incorrect SQL and preventing the table from being created.

To fix this problem, it was only necessary to clear the creation of the foreign key.

Old code: [code](https://github.com/gumpdev/worm/blob/master/src/main/java/dev/gump/worm/field/WormField.java)
```java
if(type == FieldType.ENTITY && fieldClass_relational != null){
            EntityMeta cMeta = Worm.getRegistry().getTableMeta(fieldClass_relational);
            if(cMeta.getUniqueKeyColumns().size() != 1)
                throw new WormException("Relational Worm tables need to have only one unique keys");
            WormField key = cMeta.getUniqueKeyColumns().toArray(WormField[]::new)[0];
            StringBuilder sql = new StringBuilder(key.getSqlCreation());
            sql.append(", CONSTRAINT FK_").append(getName()).append("_").append(cMeta.getName()).append(" FOREIGN KEY (").append(getName()).append(") REFERENCES ")
                    .append(cMeta.getName()).append(" (").append(key.getName()).append(")");
            if(onDelete != null)
                sql.append(" ON DELETE ").append(onDelete.getValue());
            if(onUpdate != null)
                sql.append(" ON UPDATE ").append(onUpdate.getValue());
            return sql.toString();
        }
```

New code:
```java
if(type == FieldType.ENTITY && fieldClass_relational != null){
            EntityMeta cMeta = Worm.getRegistry().getTableMeta(fieldClass_relational);
            if (cMeta.getUniqueKeyColumns().size() != 1)
                throw new WormException("Relational Worm tables need to have only one unique keys");

            WormField key = cMeta.getUniqueKeyColumns().toArray(WormField[]::new)[0];

            StringBuilder sql = new StringBuilder();
            sql.append(key.getType().getValue());
            if (key.getLength() > 0)
                sql.append('(').append(key.getLength()).append(')');

            if (!nullable)
                sql.append(" NOT NULL");

            sql.append(", CONSTRAINT FK_").append(getName()).append("_").append(cMeta.getName())
                    .append(" FOREIGN KEY (").append(getName()).append(") REFERENCES ")
                    .append(cMeta.getName()).append(" (").append(key.getName()).append(")");

            if (onDelete != null)
                sql.append(" ON DELETE ").append(onDelete.name());

            if (onUpdate != null)
                sql.append(" ON UPDATE ").append(onUpdate.name());

            return sql.toString();
        }
```

The main difference between the old and new code is that the StringBuilder does not inherit the original characteristics; it only reconstructs them with the necessary data.